### PR TITLE
fixed Candlestick route typo

### DIFF
--- a/API V2 _en.md
+++ b/API V2 _en.md
@@ -2632,7 +2632,7 @@ QC futures：https://fapi.zb.com/qc
 
 ### 7.3  Candlestick
 
-  - URL: /api/public/v1/kCline
+  - URL: /api/public/v1/kline
   - Interface Type: Http
   - Request type: GET 
 


### PR DESCRIPTION
There was a typo in Candlestick public route (/api/public/v1/kCline).
Received GET response:
```
{
    "code": 10001,
    "desc": "org.voovan.http.server.exception.RouterNotFound: Not avaliable router!",
    "data": false
}
```
Fixed by rewriting to /api/public/v1/kline